### PR TITLE
SEO: prerender routes, give the editor a crawlable heading, target simulator/Logic.ly/Logisim queries

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,6 @@
+// Prerender every route to static HTML at build time. Both routes are fully
+// static (no server load functions), so this bakes the /about copy and the
+// JSON-LD into crawlable HTML instead of relying on adapter-auto's
+// platform-dependent default. Adapter-agnostic: works with adapter-static and
+// adapter-cloudflare alike.
+export const prerender = true;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,8 +84,8 @@
 	<h1 class="sr-only">Online Logic Gate Simulator</h1>
 	<p class="sr-only">
 		Free online logic gate simulator and digital circuit builder — a no-signup, open-source
-		alternative to Logic.ly. Build circuits with AND, OR, NOT, XOR, NAND and NOR gates, generate
-		truth tables and boolean expressions, and share them with a link.
+		alternative to tools like Logic.ly and Logisim. Build circuits with AND, OR, NOT, XOR, NAND
+		and NOR gates, generate truth tables and boolean expressions, and share them with a link.
 		<a href="/about">Learn how it works</a>.
 	</p>
 	<noscript>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -77,6 +77,23 @@
 </svelte:head>
 
 <div class="container" bind:clientWidth={width} bind:clientHeight={height}>
+	<!-- Crawlable heading + intro for the editor route. Visually hidden so the
+	     editor's appearance is unchanged, but present in the prerendered HTML
+	     (Googlebot renders JS and would otherwise see only the canvas) and read
+	     by screen readers. Single, accurate H1 matching the page's purpose. -->
+	<h1 class="sr-only">Online Logic Gate Simulator</h1>
+	<p class="sr-only">
+		Free online logic gate simulator and digital circuit builder — a no-signup, open-source
+		alternative to Logic.ly. Build circuits with AND, OR, NOT, XOR, NAND and NOR gates, generate
+		truth tables and boolean expressions, and share them with a link.
+		<a href="/about">Learn how it works</a>.
+	</p>
+	<noscript>
+		<p class="noscript-note">
+			Logic Nodes is a free online logic gate simulator. Enable JavaScript to build and simulate
+			circuits, or read the <a href="/about">feature overview and guide</a>.
+		</p>
+	</noscript>
 	<canvas bind:this={canvas} width={width * dpi} height={height * dpi} />
 	<div class="canvasOverlayContainerWrapper">
 		<div class="overlayContainer" bind:this={canvasOverlayContainer} />
@@ -110,6 +127,30 @@
 		-moz-user-select: none;
 		-ms-user-select: none;
 		user-select: none;
+	}
+
+	/* Present in the DOM for crawlers and screen readers, but not painted, so the
+	   editor layout is untouched. */
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+	}
+
+	.noscript-note {
+		position: absolute;
+		top: 40px;
+		left: 12px;
+		right: 12px;
+		z-index: 3;
+		color: #ccc;
+		font: normal normal normal 14px/1.5 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	}
 
 	canvas {

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -75,6 +75,14 @@
 					},
 					{
 						'@type': 'Question',
+						name: 'Is Logic Nodes a free alternative to Logic.ly?',
+						acceptedAnswer: {
+							'@type': 'Answer',
+							text: 'Yes. Logic Nodes is a free, open-source logic gate simulator that runs in your browser with no account and no install, so it works as a free alternative to paid tools like Logic.ly for building and simulating digital logic circuits.'
+						}
+					},
+					{
+						'@type': 'Question',
 						name: 'Where are my circuits saved?',
 						acceptedAnswer: {
 							'@type': 'Answer',
@@ -104,10 +112,10 @@
 </script>
 
 <svelte:head>
-	<title>About Logic Nodes | Free Online Logic Gate Simulator</title>
+	<title>Logic Nodes — Logic Gate Simulator, Truth Tables &amp; Boolean Algebra</title>
 	<meta
 		name="description"
-		content="What Logic Nodes is and how to use it: a free online logic gate simulator with truth tables, custom nodes, and shareable circuits."
+		content="Free online logic gate simulator and digital circuit builder — an open-source alternative to Logic.ly. Truth tables, boolean expressions, custom nodes, shareable circuits."
 	/>
 	<link rel="canonical" href="https://nodes.kriyak.com/about" />
 	<meta property="og:type" content="website" />
@@ -133,8 +141,9 @@
 		<div class="hero-copy">
 			<h1>Build logic circuits in your&nbsp;browser</h1>
 			<p class="sub">
-				A free logic gate simulator for students, hobbyists, and anyone learning digital logic.
-				Wire up gates, watch the signals flow, and read off the truth table.
+				A free logic gate simulator and digital circuit builder for students, hobbyists, and
+				anyone learning digital logic — an open-source alternative to Logic.ly. Wire up gates,
+				watch the signals flow, and read off the truth table.
 			</p>
 			<div class="hero-actions">
 				<a class="cta" href="/">Start building</a>
@@ -302,10 +311,11 @@
 	<section class="learn">
 		<h2>Made for learning digital logic</h2>
 		<p>
-			Logic Nodes started as a way to understand logic gates properly and grew into a full
-			circuit editor. It's well suited for boolean algebra homework, building an SR latch or a
-			half adder for the first time, or experimenting with feedback and clocks. Teachers can
-			share example circuits with a link, and students need nothing but a browser.
+			Logic Nodes started as a way to understand logic gates properly and grew into a full logic
+			gate editor — a node-based editor (a hand-built node canvas) and digital circuit simulator
+			in one. It's well suited for boolean algebra homework, building an SR latch or a half adder
+			for the first time, or experimenting with feedback and clocks. Teachers can share example
+			circuits with a link, and students need nothing but a browser.
 		</p>
 		<a class="screenshot-frame" href="/" aria-label="Open the simulator">
 			<img
@@ -326,6 +336,14 @@
 			<p>
 				Yes. Free, open source under Apache 2.0, and it runs entirely in your browser. No
 				account, no tracking.
+			</p>
+		</details>
+		<details>
+			<summary>Is it a free alternative to Logic.ly?</summary>
+			<p>
+				Yes. Logic Nodes is a free, open-source logic gate simulator in the browser, so it works
+				as a free alternative to paid tools like Logic.ly for building and simulating digital
+				logic circuits.
 			</p>
 		</details>
 		<details>

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -75,10 +75,10 @@
 					},
 					{
 						'@type': 'Question',
-						name: 'Is Logic Nodes a free alternative to Logic.ly?',
+						name: 'Is Logic Nodes a free alternative to Logic.ly or Logisim?',
 						acceptedAnswer: {
 							'@type': 'Answer',
-							text: 'Yes. Logic Nodes is a free, open-source logic gate simulator that runs in your browser with no account and no install, so it works as a free alternative to paid tools like Logic.ly for building and simulating digital logic circuits.'
+							text: 'Yes. Logic Nodes is a free, open-source logic gate simulator that runs entirely in your browser with no account and no install, so it works as an alternative to paid tools like Logic.ly and to desktop apps like Logisim for building and simulating digital logic circuits online.'
 						}
 					},
 					{
@@ -142,7 +142,8 @@
 			<h1>Build logic circuits in your&nbsp;browser</h1>
 			<p class="sub">
 				A free logic gate simulator and digital circuit builder for students, hobbyists, and
-				anyone learning digital logic — an open-source alternative to Logic.ly. Wire up gates,
+				anyone learning digital logic — an open-source alternative to tools like Logic.ly and
+				Logisim. Wire up gates,
 				watch the signals flow, and read off the truth table.
 			</p>
 			<div class="hero-actions">
@@ -339,11 +340,11 @@
 			</p>
 		</details>
 		<details>
-			<summary>Is it a free alternative to Logic.ly?</summary>
+			<summary>Is it a free alternative to Logic.ly or Logisim?</summary>
 			<p>
-				Yes. Logic Nodes is a free, open-source logic gate simulator in the browser, so it works
-				as a free alternative to paid tools like Logic.ly for building and simulating digital
-				logic circuits.
+				Yes. Logic Nodes is a free, open-source logic gate simulator that runs in the browser, so
+				it works as an alternative to paid tools like Logic.ly and to desktop apps like Logisim
+				for building and simulating digital logic circuits online.
 			</p>
 		</details>
 		<details>

--- a/static/sitemap.xml
+++ b/static/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://nodes.kriyak.com/</loc></url>
-  <url><loc>https://nodes.kriyak.com/about</loc></url>
+  <url><loc>https://nodes.kriyak.com/</loc><lastmod>2026-07-23</lastmod><priority>1.0</priority></url>
+  <url><loc>https://nodes.kriyak.com/about</loc><lastmod>2026-07-23</lastmod><priority>0.8</priority></url>
 </urlset>


### PR DESCRIPTION
## Why

The tool at nodes.kriyak.com is under-indexed relative to its content: the showcase page at kriyak.com/project/logic-nodes/ ranks around 20 while the tool's own /about ranks around 47, and the primary `/` route shipped no crawlable text at all. Search Console shows real, unmet demand for generic queries the pages were not targeting, such as "logic gate simulator online", "free logic.ly alternative", "logisim online", "logic gate builder/editor", and "node canvas".

## Changes

- **Prerender all routes to static HTML.** New `src/routes/+layout.ts` with `prerender = true`. Both routes are fully static (no server load functions), so this bakes the /about copy and JSON-LD into crawlable HTML instead of depending on `adapter-auto`'s platform-dependent default. It is adapter-agnostic (works with `adapter-static` and `adapter-cloudflare`). Nothing under `src/nodesystem/**` touches browser APIs at module load, so the editor route prerenders without a `document is not defined` error.
- **Crawlable heading on the editor route** (`src/routes/+page.svelte`): a visually-hidden (`sr-only`) `<h1>` "Online Logic Gate Simulator" plus a one-sentence intro, and a `<noscript>` fallback. It is present in the prerendered HTML and read by screen readers, with zero change to the editor's appearance (no shrink, no visible chrome). Googlebot renders JS and would otherwise see only the `<canvas>`.
- **Keyword and positioning copy on /about**: "digital circuit builder", "logic gate editor", and "node-based editor / node canvas" woven into existing copy, plus a distinct `<title>` so it is no longer a near-duplicate of `/`.
- **"Free alternative" FAQ**: a new "Is it a free alternative to Logic.ly or Logisim?" entry in both the visible `<details>` and the `FAQPage` JSON-LD. Logisim (a desktop app people search to run in the browser) and Logic.ly (paid) are honest targets; Multisim and CircuitVerse were deliberately left out to avoid over-claiming.
- **Sitemap**: added `lastmod` and `priority` to `static/sitemap.xml` to prompt re-crawl.

## Positioning

`/` owns the transactional "logic gate simulator online" and "free Logic.ly alternative" intent; /about is the content landing (truth tables, boolean algebra, FAQ). Canonicals stay self-referential, since the subdomain tool and the kriyak.com showcase serve different intent and should not cross-canonicalize.

## Verification

`pnpm build` succeeds and prerenders both routes. The built `prerendered/pages/index.html` and `about.html` contain the new `<h1>`, the Logic.ly/Logisim copy, the new title, and the `FAQPage` schema.

## Follow-ups

- If Cloudflare Bot Fight Mode is ever enabled for the subdomain, confirm verified bots (Googlebot) are allowed; that would outweigh any on-page fix.
- After deploy: ping IndexNow (the key is already hosted) and request indexing for `/` and /about in Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)